### PR TITLE
[고도화] 엔티티 코드 리팩토링 -  엔티티의 equal(), hashcode() 비교 로직에 getter 적용

### DIFF
--- a/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/Article.java
+++ b/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/Article.java
@@ -65,11 +65,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/ArticleComment.java
+++ b/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/ArticleComment.java
@@ -51,11 +51,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/UserAccount.java
+++ b/2.board-service/board-practice/src/main/java/com/board/boardpractice/domain/UserAccount.java
@@ -56,11 +56,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
스프링 데이터 JPA로 엔티티를 다룰때, 엔티티 데이터는 하이버네이트 구현체가 만든 프록시 객체를 이용하여 지연 로딩할 수 있다.
따라서 엔티티를 조회할 때 필드에 직접 접근하면 `id == null` 인 상황이 있을 수 있고, 이러면 올바른 비교를 하지 못 하게 된다.
getter 를 사용하면 이러한 문제를 예방할 수 있다.

this closes #41 
